### PR TITLE
Fix _process_profile arg mismatch

### DIFF
--- a/mensetsu.py
+++ b/mensetsu.py
@@ -2564,6 +2564,7 @@ class EventCog(commands.Cog):
             'failed': False,
             'profile_message_id': None,
             'pending_inrate_confirmation': False,
+            'pending_move_confirmation': False,
         }
         await data_manager.save_data()
         request_dashboard_update(self.bot)
@@ -2907,6 +2908,8 @@ class MessageCog(commands.Cog):
         message: discord.Message,
         cp: Dict[str, Any],
         progress_key: str,
+        *,
+        move_confirmed_by_user: bool = False,
     ):
         """プロフィール本文らしい投稿 / 編集を評価"""
         cp["profile_message_id"] = message.id
@@ -2915,7 +2918,7 @@ class MessageCog(commands.Cog):
             message.content,
             debug=True,
             inrate_cleared=cp.get("pending_inrate_confirmation", False),
-            move_cleared=cp.get("pending_move_confirmation", False),
+            move_cleared=move_confirmed_by_user or not cp.get("pending_move_confirmation", False),
         )
 
         # ----------- OK -----------


### PR DESCRIPTION
## Summary
- add `pending_move_confirmation` field when creating candidate progress
- allow `_process_profile` to accept `move_confirmed_by_user` and pass it to the AI evaluation

## Testing
- `python -m py_compile mensetsu.py`
- `python -m py_compile 面接.py 面接2.py`

------
https://chatgpt.com/codex/tasks/task_e_6840c98b307083258bb374f90904cffc